### PR TITLE
added voice back in and fixed issues with colourblindness not working properly

### DIFF
--- a/PlantAR/PlantAR/MainTabView.swift
+++ b/PlantAR/PlantAR/MainTabView.swift
@@ -6,6 +6,7 @@ import CoreLocation
 import PhotosUI
 import WebKit
 import UserNotifications
+import AVFoundation
 
 // MARK: - Location Manager
 
@@ -2871,6 +2872,9 @@ struct PartPopupOverlay: View {
     let onDismiss: () -> Void
     let onSeeAll: () -> Void
 
+    @State private var synthesizer = AVSpeechSynthesizer()
+    @State private var isSpeaking = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Pull handle
@@ -2884,7 +2888,7 @@ struct PartPopupOverlay: View {
             .padding(.top, 12)
             .padding(.bottom, 18)
 
-            // Name + dismiss
+            // Name + speaker + dismiss
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(part.name)
@@ -2896,7 +2900,20 @@ struct PartPopupOverlay: View {
                         .foregroundColor(.secondary)
                 }
                 Spacer()
-                Button(action: onDismiss) {
+                Button(action: toggleSpeech) {
+                    Image(systemName: isSpeaking ? "speaker.wave.2.fill" : "speaker.wave.2")
+                        .font(.system(size: 20))
+                        .foregroundColor(.plantPrimary)
+                        .frame(width: 40, height: 40)
+                        .background(Color.plantPrimary.opacity(0.1))
+                        .clipShape(Circle())
+                }
+                .accessibilityLabel(isSpeaking ? "Stop speaking" : "Listen to description")
+                Button(action: {
+                    synthesizer.stopSpeaking(at: .immediate)
+                    isSpeaking = false
+                    onDismiss()
+                }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 26))
                         .foregroundColor(Color(.systemGray3))
@@ -2913,7 +2930,11 @@ struct PartPopupOverlay: View {
                 .padding(.top, 10)
 
             // Link to full anatomy sheet
-            Button(action: onSeeAll) {
+            Button(action: {
+                synthesizer.stopSpeaking(at: .immediate)
+                isSpeaking = false
+                onSeeAll()
+            }) {
                 HStack(spacing: 4) {
                     Text("View all plant anatomy")
                         .font(.system(size: 14, weight: .semibold))
@@ -2932,6 +2953,24 @@ struct PartPopupOverlay: View {
                 .fill(Color.white)
                 .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: -6)
         )
+        .onDisappear {
+            synthesizer.stopSpeaking(at: .immediate)
+            isSpeaking = false
+        }
+    }
+
+    private func toggleSpeech() {
+        if synthesizer.isSpeaking {
+            synthesizer.stopSpeaking(at: .immediate)
+            isSpeaking = false
+        } else {
+            let utterance = AVSpeechUtterance(string: "\(part.name). \(part.function)")
+            utterance.rate = 0.5
+            utterance.pitchMultiplier = 1.0
+            utterance.volume = 1.0
+            synthesizer.speak(utterance)
+            isSpeaking = true
+        }
     }
 }
 

--- a/PlantAR/PlantAR/PlantARTheme.swift
+++ b/PlantAR/PlantAR/PlantARTheme.swift
@@ -223,7 +223,7 @@ struct QuizOptionButtonStyle: ButtonStyle {
                 .foregroundColor(.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Icon alongside color so colorblind users can distinguish correct/incorrect
+            // Icon alongside colour so colourblind users can tell correct from incorrect
             if let isCorrect = isCorrect {
                 Image(systemName: isCorrect ? "checkmark.circle.fill" : "xmark.circle.fill")
                     .font(.system(size: 20, weight: .semibold))

--- a/PlantAR/PlantAR/PlantARTheme.swift
+++ b/PlantAR/PlantAR/PlantARTheme.swift
@@ -217,19 +217,29 @@ struct QuizOptionButtonStyle: ButtonStyle {
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.bodyLarge)
-            .foregroundColor(.textPrimary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(PlantSpacing.lg)
-            .background(backgroundColor)
-            .cornerRadius(PlantRadius.md)
-            .overlay(
-                RoundedRectangle(cornerRadius: PlantRadius.md)
-                    .stroke(borderColor, lineWidth: isSelected || isCorrect != nil ? 2 : 0)
-            )
-            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
-            .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
+        HStack(spacing: PlantSpacing.sm) {
+            configuration.label
+                .font(.bodyLarge)
+                .foregroundColor(.textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Icon alongside color so colorblind users can distinguish correct/incorrect
+            if let isCorrect = isCorrect {
+                Image(systemName: isCorrect ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundColor(isCorrect ? .botanicalSuccess : .botanicalError)
+                    .accessibilityLabel(isCorrect ? "Correct" : "Incorrect")
+            }
+        }
+        .padding(PlantSpacing.lg)
+        .background(backgroundColor)
+        .cornerRadius(PlantRadius.md)
+        .overlay(
+            RoundedRectangle(cornerRadius: PlantRadius.md)
+                .stroke(borderColor, lineWidth: isSelected || isCorrect != nil ? 2 : 0)
+        )
+        .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+        .animation(.easeInOut(duration: 0.15), value: configuration.isPressed)
     }
 }
 


### PR DESCRIPTION
## Changes

- **Voice/speaker button restored** — tapping the speaker icon on the plant part popup reads the part name and function description aloud using AVSpeechSynthesizer. Tapping again stops playback. Speech also stops automatically when the popup is dismissed or the user navigates to the full anatomy sheet.

- **Colourblind accessibility fix** — quiz answer options now show a checkmark or X icon alongside the green/red background, so correct and incorrect answers are distinguishable without relying on colour alone.